### PR TITLE
Fix unchecked checkboxes not being submitted

### DIFF
--- a/src/Resources/contao/templates/control/fd_control_checkbox_bs.html5
+++ b/src/Resources/contao/templates/control/fd_control_checkbox_bs.html5
@@ -1,4 +1,5 @@
 
+<input type="hidden" name="<?= $this->widget->name ?>" value="">
 <?php foreach (\Netzmacht\Contao\FormDesigner\Util\WidgetUtil::getOptions($this->widget) as $option): ?>
     <?php if ($option['type'] == 'group_start'): ?>
         <fieldset>


### PR DESCRIPTION
An unchecked checkbox will not be submitted to the server. This may lead to unexpected behavior. An empty string should be submitted instead, to represent the empty value.

Solution:
Add an empty hidden field above the checkbox, like Contao core and Form Designer do.